### PR TITLE
Update mainnet contract addresses and add changeset for production de…

### DIFF
--- a/.changeset/spotty-jars-cover.md
+++ b/.changeset/spotty-jars-cover.md
@@ -1,0 +1,5 @@
+---
+'@verify-media/verify-client': patch
+---
+
+patch to update production mainnet contract details

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const getIdentityContractAddress = (stage: string): string => {
     case 'sandbox':
       return '0xEe586a3655EB0D017643551e9849ed828Fd7c7FA' //amoy
     case 'mainnet':
-      return '0xEe586a3655EB0D017643551e9849ed828Fd7c7FA'
+      return '0x27BA7E931906FebA79dED5d32947b12f30379135'
     default:
       throw new Error(
         `stage can have one of the following values ${Object.values(STAGE).join(',')}`
@@ -37,7 +37,7 @@ export const getGraphContractAddress = (stage: string): string => {
     case 'sandbox':
       return '0xEF2E371BaFAe46a116519F18A1cfF750570E8842' //amoy
     case 'mainnet':
-      return '0x917340A034FBce4166Bffd556015D862D00021aD'
+      return '0xEF2E371BaFAe46a116519F18A1cfF750570E8842'
     default:
       throw new Error(
         `stage can have one of the following values ${Object.values(STAGE).join(',')}`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const getIdentityContractAddress = (stage: string): string => {
     case 'sandbox':
       return '0xEe586a3655EB0D017643551e9849ed828Fd7c7FA' //amoy
     case 'mainnet':
-      return 'TBD'
+      return '0xEe586a3655EB0D017643551e9849ed828Fd7c7FA'
     default:
       throw new Error(
         `stage can have one of the following values ${Object.values(STAGE).join(',')}`
@@ -37,7 +37,7 @@ export const getGraphContractAddress = (stage: string): string => {
     case 'sandbox':
       return '0xEF2E371BaFAe46a116519F18A1cfF750570E8842' //amoy
     case 'mainnet':
-      return 'TBD'
+      return '0x917340A034FBce4166Bffd556015D862D00021aD'
     default:
       throw new Error(
         `stage can have one of the following values ${Object.values(STAGE).join(',')}`
@@ -73,7 +73,7 @@ export const getLicense = (licenseType: LicenseType, stage: string): string => {
       const allowlistLicense: Record<STAGE, string> = {
         sandbox: '0x074340A85FCc5005BE0794E29e7fe1825600366B', // amoy
         testnet: '0x3fb39aEDE0f88183195c8c506DCeE227F33062d2', // amoy
-        mainnet: ''
+        mainnet: '0x141ae63032Ad3D89AA20bCC92Ab601B77Ec1d200'
       }
 
       return allowlistLicense[_stage as STAGE]
@@ -82,7 +82,7 @@ export const getLicense = (licenseType: LicenseType, stage: string): string => {
       const publicLicense: Record<STAGE, string> = {
         sandbox: '0x96BcFc032677da04B243f53fdb972ab6EC6Bc9f4', // amoy
         testnet: '0xEf71Be486abace4cCB921Bb1943351cefa208D6a', // amoy
-        mainnet: ''
+        mainnet: '0x074340A85FCc5005BE0794E29e7fe1825600366B'
       }
 
       return publicLicense[_stage as STAGE]
@@ -92,7 +92,7 @@ export const getLicense = (licenseType: LicenseType, stage: string): string => {
       const privateLicense: Record<STAGE, string> = {
         sandbox: '0x141ae63032Ad3D89AA20bCC92Ab601B77Ec1d200',
         testnet: '0x2B09b8f1855E7f309B32A738E45c7545A095fC3b',
-        mainnet: ''
+        mainnet: '0x96BcFc032677da04B243f53fdb972ab6EC6Bc9f4'
       }
 
       return privateLicense[_stage as STAGE]
@@ -102,7 +102,7 @@ export const getLicense = (licenseType: LicenseType, stage: string): string => {
       const timebasedLicense: Record<STAGE, string> = {
         sandbox: '0xFC937a068c93e5878CcD5C20f2DBaEf95d7F1Cfe',
         testnet: '0x285098018b2e01a74974ABF5d34e97f655b7e227',
-        mainnet: ''
+        mainnet: '0xFC937a068c93e5878CcD5C20f2DBaEf95d7F1Cfe'
       }
 
       return timebasedLicense[_stage as STAGE]
@@ -112,7 +112,7 @@ export const getLicense = (licenseType: LicenseType, stage: string): string => {
       const authorizerLicense: Record<STAGE, string> = {
         sandbox: '0xF2a81936441BA4fE353633b2874195792Fb41823',
         testnet: '0x7B4d19810Aa1AEc46ab790fB78E5F85214036bFb',
-        mainnet: ''
+        mainnet: '0xF2a81936441BA4fE353633b2874195792Fb41823'
       }
 
       return authorizerLicense[_stage as STAGE]

--- a/src/tests/constants.test.ts
+++ b/src/tests/constants.test.ts
@@ -34,7 +34,7 @@ describe('getIdentityContractAddress', () => {
 
   it('returns the correct contract address for mainnet', () => {
     const result = getIdentityContractAddress('mainnet')
-    expect(result).toBe('TBD')
+    expect(result).toBe('0xEe586a3655EB0D017643551e9849ed828Fd7c7FA')
   })
 
   it('throws an error for an invalid stage', () => {
@@ -63,7 +63,7 @@ describe('getGraphContractAddress', () => {
 
   it('returns the correct contract address for mainnet', () => {
     const result = getGraphContractAddress('mainnet')
-    expect(result).toBe('TBD')
+    expect(result).toBe('0x917340A034FBce4166Bffd556015D862D00021aD')
   })
 
   it('throws an error for an invalid stage', () => {

--- a/src/tests/constants.test.ts
+++ b/src/tests/constants.test.ts
@@ -34,7 +34,7 @@ describe('getIdentityContractAddress', () => {
 
   it('returns the correct contract address for mainnet', () => {
     const result = getIdentityContractAddress('mainnet')
-    expect(result).toBe('0xEe586a3655EB0D017643551e9849ed828Fd7c7FA')
+    expect(result).toBe('0x27BA7E931906FebA79dED5d32947b12f30379135')
   })
 
   it('throws an error for an invalid stage', () => {
@@ -63,7 +63,7 @@ describe('getGraphContractAddress', () => {
 
   it('returns the correct contract address for mainnet', () => {
     const result = getGraphContractAddress('mainnet')
-    expect(result).toBe('0x917340A034FBce4166Bffd556015D862D00021aD')
+    expect(result).toBe('0xEF2E371BaFAe46a116519F18A1cfF750570E8842')
   })
 
   it('throws an error for an invalid stage', () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '1.1.0'
+export const version = '1.1.1'


### PR DESCRIPTION
This pull request includes updates to the production mainnet contract details in the `src/constants.ts` file and corresponding test updates in the `src/tests/constants.test.ts` file. The changes ensure that the correct contract addresses are returned for the mainnet stage.

### Updates to contract details:

* Updated the mainnet address in the `getIdentityContractAddress` function to `0xEe586a3655EB0D017643551e9849ed828Fd7c7FA`.
* Updated the mainnet address in the `getGraphContractAddress` function to `0x917340A034FBce4166Bffd556015D862D00021aD`.
* Updated the mainnet addresses in the `getLicense` function for various license types:
  * [`allowlistLicense`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L76-R76): `0x141ae63032Ad3D89AA20bCC92Ab601B77Ec1d200`
  * [`publicLicense`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L85-R85): `0x074340A85FCc5005BE0794E29e7fe1825600366B`
  * [`privateLicense`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L95-R95): `0x96BcFc032677da04B243f53fdb972ab6EC6Bc9f4`
  * [`timebasedLicense`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L105-R105): `0xFC937a068c93e5878CcD5C20f2DBaEf95d7F1Cfe`
  * [`authorizerLicense`](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L115-R115): `0xF2a81936441BA4fE353633b2874195792Fb41823`

### Corresponding test updates:

* Updated the expected mainnet address in the `getIdentityContractAddress` test to `0xEe586a3655EB0D017643551e9849ed828Fd7c7FA`.
* Updated the expected mainnet address in the `getGraphContractAddress` test to `0x917340A034FBce4166Bffd556015D862D00021aD`.

### Changeset:

* Added a changeset file to document the patch update for production mainnet contract details